### PR TITLE
fix(tslint.json): adds options object to max line length

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,10 @@
   ],
   "rulesDirectory": [],
   "rules": {
-    "max-line-length": 140,
+    "max-line-length": {
+      "options": 140,
+      "severity": "error"
+    },
     "quotemark": [
       true,
       "single"


### PR DESCRIPTION
linting breaks without options object in TSLint 5.9, see tslint issue [3644](https://github.com/palantir/tslint/issues/3644)