### PR TITLE
feat(tslint.json): set no-return-await to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 
 .DS_Store
+.idea

--- a/tslint.json
+++ b/tslint.json
@@ -28,6 +28,7 @@
     "jsx-no-multiline-js": false,
     "jsx-boolean-value": false,
     "jsx-wrap-multiline": false,
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-return-await": false
   }
 }


### PR DESCRIPTION
I propose setting the `no-return-await` lint rule to false, for these reasons:

1. This rule makes nested `return await` expressions illegal, even though the `await` is necessary, for example a function such as `async () => await (await object()).method()`.
2. Non-nested `return await` expressions sometimes have value to help clarify the fact that a function returns a Promise, even though there is a performance penalty for adding an extra Promise to wrap the `return await` call. Sometimes the performance penalty is an acceptable tradeoff for code clarity.